### PR TITLE
Add full YAML configurations for assistant stack

### DIFF
--- a/config/chat_adapter.yaml
+++ b/config/chat_adapter.yaml
@@ -1,1 +1,109 @@
-service: chat_adapter
+adapter:
+  name: "ChatAdapter"
+  version: "1.0"
+
+  runtime:
+    metrics_enabled: true
+    trace_enabled: true
+    timeout_ms: 1200
+
+  preprocess:
+    clean:
+      unicode_nfkc: true
+      strip_control_chars: true
+      trim_whitespace: true
+      collapse_whitespace: true
+      normalize_quotes: true
+      normalize_dashes: true
+      normalize_zwnj: "preserve-fa"
+      normalize_digits:
+        fa_to_ascii: true
+        ar_to_ascii: true
+      max_text_len: 8000
+      truncate_strategy: "hard_tail"
+
+    detect_urls:
+      enabled: true
+      regex_ref: "defaults.url"
+      allow_schemes: ["http","https"]
+      disallow_domains: []
+      max_urls: 5
+
+    detect_media_types:
+      enabled: true
+      rules:
+        - when: "attachment.mime.startswith('image/')"
+          as_media_type: "image"
+        - when: "attachment.mime.startswith('audio/')"
+          as_media_type: "audio"
+        - when: "attachment.mime.startswith('video/')"
+          as_media_type: "video"
+        - when: "attachment.mime == 'application/pdf'"
+          as_media_type: "document"
+        - when: "attachment.mime.startswith('application/')"
+          as_media_type: "document"
+      accept_mime_prefixes: ["image/","audio/","video/","application/pdf","application/"]
+      reject_mime_prefixes: ["application/x-msdownload","application/x-dosexec"]
+      max_files: 5
+
+    attachments_guard:
+      max_total_bytes: 800000000
+      reject_if_missing_id: true
+      compute_sha256_if_missing: false
+
+  locale:
+    default_locale: "en-US"
+    allow_user_override: true
+    infer_order: ["explicit","session","user_profile","platform","default"]
+    timezone:
+      default_tz: "UTC"
+      allow_user_override: true
+      tz_by_locale:
+        "fa-IR": "Asia/Tehran"
+        "en-US": "America/Los_Angeles"
+        "en-GB": "Europe/London"
+        "nl-NL": "Europe/Amsterdam"
+
+  memory:
+    sticky_carry:
+      enabled: true
+      sticky_keys: ["last_file","last_url","last_text","last_intent_hint"]
+      ttl_turns: 3
+      clear_on_negation:
+        enabled: true
+        scope: ["file","url","text"]
+        negation_markers:
+          en: ["not that","use a different file","different link","another one","ignore previous"]
+          fa: ["نه همون","فایل قبلی نه","لینک قبلی نه","یکی دیگه","عوضش کن"]
+      precedence:
+        prefer_current_attachments_over_stickies: true
+        prefer_current_urls_over_stickies: true
+
+  hints:
+    target_lang_default: "fa"
+    provider_default:
+      media: "youtube"
+      ocr: "tesseract"
+      stt: "whisper"
+    safety_mode: "standard"
+    propagate_to_router: ["target_lang","provider","safety_mode"]
+
+  contracts:
+    envelope_schema_ref: "MessageEnvelope@1"
+
+  defaults:
+    url: "https?://\\S+"
+
+  observability:
+    logging:
+      level: "INFO"
+      redact_pii: true
+      include_sections: ["preprocess","locale","memory","hints","envelope"]
+    metrics:
+      enabled: true
+      counters: ["incoming_turns","attachments_seen","urls_seen","stickies_used","negations_detected"]
+    traces:
+      enabled: true
+      tags:
+        component: "ChatAdapter"
+        version: "1.0"

--- a/config/dispatch_controller.yaml
+++ b/config/dispatch_controller.yaml
@@ -1,1 +1,130 @@
-service: dispatch_controller
+dispatch:
+  name: "Dispatch Controller"
+  version: "1.2.0"
+  runtime:
+    engine: "python-service"
+    timeout_ms: 2500
+    trace_enabled: true
+    metrics_enabled: true
+    clock: "utc"
+
+  inputs_contract: "DispatchInput@1"
+  outputs_contract: "DispatchDecision@1"
+
+  behavior:
+    attempt_auto_slot_enrich_on_ask: true
+    respect_orchestrator_ask: false
+    max_slotfill_rounds: 1
+    min_field_confidence: 0.70
+    min_overall_confidence: 0.65
+    fail_closed_on_policy_violation: true
+    low_risk_side_effects_auto_execute: true
+    locale_fallback: "en-US"
+
+  preflight:
+    checks:
+      - name: "domain_allowed"
+      - name: "agent_capable"
+      - name: "resource_presence"
+      - name: "resource_type_match"
+      - name: "quota_caps"
+      - name: "security_labels_ok"
+    capability_matrix_uri: "s3://router/capability_matrix.yaml"
+    caps:
+      stt_max_seconds: 1800
+      media_max_bytes: 500000000
+      vision_max_pixels: 268435456
+    policy:
+      allow_domains: ["core","media","images","video","ocr","qr","table","schedule","network","finance","music"]
+      deny_domains: []
+    filetype_hints:
+      image: ["image/jpeg","image/png","image/webp"]
+      audio: ["audio/mpeg","audio/wav","audio/flac","audio/aac"]
+      video: ["video/mp4","video/webm","video/quicktime"]
+      document: ["application/pdf","image/png","image/jpeg"]
+
+  slotfill_llm:
+    enabled: true
+    model: ""
+    temperature: 0.0
+    max_tokens: 384
+    max_calls_per_turn: 2
+    no_regex_validation: true
+    prompts:
+      extract_ref: "slotfill_extract_v1"
+      verify_ref: "slotfill_verify_v1"
+    allowlist_intents:
+      - "video.thumbnail"
+      - "video.gif"
+      - "music.send"
+      - "music.playlist.add"
+      - "music.playlist.remove"
+      - "sched.book"
+      - "sched.reschedule"
+      - "finance.fx.convert"
+      - "finance.crypto.ticker"
+    denylist_fields: []
+    use_memory:
+      short_ctx_turns: 4
+      include_entity_bag: true
+      include_last_file_url: true
+      include_last_intent: true
+    acceptance:
+      per_field_min_confidence:
+        recipient: 0.80
+        booking_ref: 0.85
+      overall_min_confidence: 0.65
+      verify_required: true
+      resolve_names_for_ids:
+        - "playlist_id<-playlist_name"
+        - "track_source<-last_file_or_url"
+
+  safety:
+    sensitive_intents:
+      require_confirm:
+        - "files.delete"
+        - "controls.set_quiet_hours"
+        - "controls.mute_24h"
+        - "proxy.import"
+      double_confirm:
+        - "files.delete"
+        - "proxy.import"
+      low_risk_auto:
+        - "music.send"
+        - "video.thumbnail"
+        - "video.gif"
+        - "doc.ocr"
+    user_confirmation:
+      enabled: true
+      prompt_ref: "confirm_action_v1"
+      accept_keywords:
+        en: ["yes","confirm","go ahead","do it","please proceed"]
+        fa: ["بله","باشه","ادامه بده","انجام بده"]
+      decline_keywords:
+        en: ["no","cancel","stop","abort"]
+        fa: ["نه","لغو","توقف"]
+      require_exact_phrase_for_double_confirm:
+        phrase_en: "CONFIRM"
+        phrase_fa: "تایید"
+
+  decisions:
+    ask_when_missing_after_slotfill: true
+    ask_prompt_ref: "ask_missing_v1"
+    ask_style_by_locale:
+      en-US: { tone: "friendly", register: "neutral" }
+      fa-IR: { tone: "formal", register: "polite" }
+    enqueue_when_ready: true
+    attach_agent_family_from: "task_spec_or_override"
+    enqueue_payload:
+      include: ["aor_id","idempotency_key","agent","task","inputs","session"]
+      redact_pii: true
+      ttl_s: 1800
+
+  observability:
+    emit:
+      preflight: ["checks_passed","cap_hits","resource_binds"]
+      slotfill: ["missing_before","extracted","verified","confidences","missing_after"]
+      safety: ["sensitive_intent","confirm_needed","confirm_state"]
+      decision: ["action","why","agent","queue_id"]
+    redact_pii: true
+    retain_days: 14

--- a/config/orchestrator.yaml
+++ b/config/orchestrator.yaml
@@ -1,1 +1,169 @@
-service: orchestrator
+orchestrator:
+  name: "AOR Orchestrator"
+  version: "1.2.0"
+  runtime:
+    engine: "python-service"
+    trace_enabled: true
+    metrics_enabled: true
+    timeout_ms: 1500
+    clock: "utc"
+    locale_default: "en-US"
+
+  inputs_contract: "OrchestratorInput@1"
+  outputs_contract: "AOR@1"
+
+  aor:
+    schema:
+      version: "1.2.0"
+    fields:
+      include:
+        - "aor_id"
+        - "schema_version"
+        - "session_id"
+        - "turn_id"
+        - "tenant_id"
+        - "user_id"
+        - "nodes"
+        - "edges"
+        - "created_at"
+        - "idempotency_key"
+        - "next_action"
+        - "usage"
+        - "sr_debug"
+        - "plan_source"
+        - "security_labels"
+      validation:
+        nodes_max: 8
+        edges_max: 16
+        require_nonempty_nodes: true
+        forbid_empty_intent: true
+      normalize:
+        sort_node_inputs_keys: true
+        canonicalize_timestamps: true
+        prune_nulls: true
+        redact_values_by_label:
+          pii: true
+          secrets: true
+
+  task_specs:
+    source: "uri"
+    uri: "s3://router/task_specs.yaml"
+    cache_ttl_s: 600
+    refresh_on_not_found: true
+    strict_missing: true
+
+  node_builder:
+    input_binding_precedence:
+      - "router.merge_prepare.bound_stickies"
+      - "router.finalize.llm_cues"
+      - "envelope.adapter_hints"
+    compose_trivial:
+      enabled: true
+      rules:
+        - name: "date+time→datetime"
+          when_present: ["date","time"]
+          produce: "datetime"
+    defaults:
+      allow_missing_optional: true
+    agent_family_map:
+      "video.*": "media_agent"
+      "media.*": "media_agent"
+      "music.*": "media_agent"
+      "doc.*": "vision_agent"
+      "image.*": "vision_agent"
+      "qr.*": "vision_agent"
+      "barcode.*": "vision_agent"
+      "table.*": "vision_agent"
+      "sched.*": "calendar_agent"
+      "network.*": "network_agent"
+      "finance.*": "markets_agent"
+      "chat.general": "nlp_agent"
+
+  idempotency:
+    enabled: true
+    algorithm: "sha256_hmac"
+    secret_ref: "env:IDEMPOTENCY_HMAC_KEY"
+    dedupe_window_s: 180
+    include_fields:
+      - "tenant_id"
+      - "user_id"
+      - "session_id"
+      - "router.finalize.chosen_intent"
+      - "router.merge_prepare.bound_stickies"
+      - "router.finalize.plan_skeleton.tasks"
+      - "task_specs.version"
+    exclude_fields:
+      - "timestamps"
+      - "sr_debug"
+      - "transient"
+    collision_policy: "reuse_existing"
+    normalize:
+      sort_keys: true
+      collapse_whitespace: true
+      iso_timestamps: true
+
+  next_action:
+    ask_when_missing_required: true
+    ask_at_most: 1
+    clarify_templates:
+      en-US:
+        missing: "Please provide **{field}**."
+        pick_source: "Should I use the last file or the link you mentioned?"
+      fa-IR:
+        missing: "لطفاً **{field}** را مشخص کنید."
+        pick_source: "از فایل قبلی استفاده کنم یا لینکی که گفتید؟"
+    allow_execute_when_all_required_present: true
+
+  telemetry:
+    sinks:
+      - type: "kafka"
+        topic: "aor-events-v1"
+        required: true
+      - type: "metrics"
+        ns: "router.aor"
+        required: false
+    emit_fields:
+      - "aor_id"
+      - "session_id"
+      - "turn_id"
+      - "tenant_id"
+      - "user_id_hash"
+      - "chosen_intent"
+      - "node_count"
+      - "edge_count"
+      - "decision"
+      - "idempotent_reused"
+      - "latency_ms"
+      - "caps_hit"
+      - "policy_fallback"
+    redact:
+      pii: true
+      secrets: true
+    retain_days: 14
+
+  usage:
+    accounting:
+      enable_predictive_costing: true
+      llm_cost_model: "s3://billing/llm_costs_v1.json"
+    collect:
+      router_token_usage: true
+      adapter_token_usage: true
+      orchestration_cpu_ms: true
+
+  security:
+    labels:
+      propagate_from_router: true
+      default: ["internal"]
+    pii_detection:
+      enabled: true
+      strategy: "rule-lite"
+
+  sr_debug:
+    include_sections:
+      - "gate"
+      - "ranker.dense_hits"
+      - "ranker.llm_prior"
+      - "fusion"
+      - "reranker.features"
+      - "calibrated_probs"
+    redact_pii: true

--- a/config/router.yaml
+++ b/config/router.yaml
@@ -1,1 +1,177 @@
-service: router
+router:
+  name: "ConfigLLMRouter"
+  version: "1.0"
+
+  runtime:
+    trace_enabled: true
+    metrics_enabled: true
+    timeout_ms: 2000
+
+  gate:
+    modality_detection:
+      allow_llm: true
+      infer_keys: ["has_url","has_file","has_image","has_voice","has_video","has_text"]
+      map_files_by_media_type: true
+    family_selection:
+      policy_allowlist:
+        allow: ["core","media","images","video","ocr","qr","table","schedule","network","finance","music"]
+        deny: []
+      resource_gate:
+        enforce_modal_requirements: true
+        min_overlap: 0.15
+    soft_cues_to_prior:
+      enabled: true
+      decay: 0.30
+
+  thresholds:
+    domain_lock_margin: 0.18
+    tau_exec: 0.62
+    tau_clarify: 0.42
+    tau_fallback: 0.20
+
+  models:
+    dense_sr:
+      embedder: ""
+      index_uri: ""
+      normalize: true
+      topK_sem: 30
+      min_score: 0.05
+    llm_recall:
+      model: ""
+      temperature: 0.1
+      max_tokens: 256
+      topK_llm: 12
+      prompt_template_ref: "recall_v1"
+    memory_summarizer:
+      model: ""
+      temperature: 0.1
+      max_tokens: 256
+    cross_encoder:
+      enabled: true
+      model: ""
+      max_pairs: 12
+    calibrator:
+      method: "isotonic"
+      table_uri: ""
+
+  ranker:
+    candidate_generation:
+      dense_sr:
+        enabled: true
+        topK: 30
+        family_filter: "soft"
+      llm_recall:
+        enabled: true
+        allowed_families: []
+        use_memory_context: true
+        topK: 12
+        prompt_template_ref: "recall_v1"
+        include_rationales: true
+    fusion:
+      method: "weighted_rrf"
+      weights:
+        dense_sr: 0.6
+        llm_prior: 0.4
+      shortlist_topN: 12
+    precision_rerank:
+      enabled: true
+      cross_encoder:
+        enabled: true
+        max_pairs: 12
+      features:
+        include: ["sr_score","ce_score","slot_readiness_llm","resource_match","session_affinity","memory_consistency","topic_shift","safety_hint"]
+      ltr_blend:
+        method: "logistic"
+        model_uri: ""
+      calibration:
+        method: "isotonic"
+        table_uri: ""
+
+  merge_prepare:
+    sticky_bind:
+      prefer_last_file_for_families: ["media","images","video","ocr","qr","table","music"]
+      prefer_last_url_for_families: ["media","video","core"]
+      guard_user_negation_phrases:
+        - "not that"
+        - "use a different file"
+        - "different link"
+        - "نه همون"
+    auto_fill_trivial_pairs:
+      rules:
+        - name: "date_plus_time_to_datetime"
+          when_present: ["date","time"]
+          produce: "datetime"
+        - name: "file_or_url_prefer_file"
+          when_present: ["file_id","url"]
+          produce: "source"
+          precedence: ["file_id","url"]
+    canonicalize:
+      datetime_to_iso_8601: true
+      timezone: "session"
+
+  policy:
+    provider_allowlist:
+      stt: ["whisper","deepgram"]
+      translate: ["gpt"]
+      ocr: ["tesseract"]
+    caps:
+      stt: { max_duration_s: 1800 }
+      media: { max_bytes: 500000000 }
+      vision: { max_pixels: 268435456 }
+    safe_fallbacks:
+      when_external_scrape_denied: "inline_tldr"
+      when_video_too_long: "chapters_only"
+    pre_clarify:
+      enabled: true
+      ask_at_most: 1
+      friendly_labels_ref: "clarify_prompts"
+      triggers:
+        - reason: "missing_critical_single"
+          if_missing_keys_one_of: ["start","end","at","recipient","playlist_id","booking_ref"]
+        - reason: "ambiguous_source"
+          if_conflict: ["file_id","url"]
+        - reason: "provider_cap_exceeded"
+          when_cap_hit: true
+
+  finalize:
+    plan_skeleton:
+      max_tasks: 3
+      include_top_intent_only: true
+      attach_llm_cues_as_nonbinding: true
+      include_missing_keys_summary: true
+    clarify_fallback:
+      when_below_tau_clarify: true
+      message_style_by_locale:
+        en-US: { tone: "friendly", register: "neutral" }
+        fa-IR: { tone: "formal", register: "polite" }
+    graceful_fallback:
+      below_tau_fallback_to: "chat.general"
+      text_when_fallback:
+        en-US: "I can help with that—could you say it another way?"
+        fa-IR: "می‌تونم کمک کنم—ممکنه کمی واضح‌تر توضیح بدید؟"
+
+  prompts:
+    recall_v1:
+      system: |
+        You are an intent recall assistant. Return top candidate intents by name only,
+        with brief rationales. Do not extract fields/slots.
+      user_template: |
+        Message:
+        - text: {text}
+        - urls: {urls}
+        - attachments: {attachments}
+        - locale: {locale}, tz: {timezone}
+        Session snapshot:
+        - last_url: {last_url}
+        - last_file: {last_file}
+        - last_intent_hint: {last_intent_hint}
+        Families gated: {families}
+        List up to {topK} intents.
+      output_schema_hint: "List[{intent: string, rationale: string}]"
+    clarify_prompts:
+      en-US:
+        missing_single: "Please provide **{field}**."
+        ambiguous_source: "Should I use the last file or the link you mentioned?"
+      fa-IR:
+        missing_single: "لطفاً **{field}** را مشخص کنید."
+        ambiguous_source: "از فایل قبلی استفاده کنم یا لینکی که گفتید؟"

--- a/config/simple_dispatcher.yaml
+++ b/config/simple_dispatcher.yaml
@@ -1,1 +1,39 @@
-service: simple_dispatcher
+simple_dispatcher:
+  name: "SimpleDispatcher"
+  version: "1.0"
+  runtime:
+    trace_enabled: true
+    metrics_enabled: true
+    timeout_ms: 2000
+  artifacts:
+    store:
+      base_uri: ""
+      sse_kms_key_ref: ""
+  security:
+    tls:
+      root_ca_ref: ""
+  endpoints:
+    media_agent:
+      url: "http://media-agent"
+      auth:
+        secret_ref: ""
+    vision_agent:
+      url: "http://vision-agent"
+      auth:
+        secret_ref: ""
+    markets_agent:
+      url: "http://markets-agent"
+      auth:
+        secret_ref: ""
+    calendar_agent:
+      url: "http://calendar-agent"
+      auth:
+        secret_ref: ""
+    network_agent:
+      url: "http://network-agent"
+      auth:
+        secret_ref: ""
+    nlp_agent:
+      url: "http://nlp-agent"
+      auth:
+        secret_ref: ""

--- a/prompts/prompts.yaml
+++ b/prompts/prompts.yaml
@@ -1,1 +1,85 @@
-prompts: {}
+prompts:
+  recall_v1:
+    system: |
+      You are an intent recall assistant. Return top candidate intents by name only,
+      with brief rationales. Do not extract fields/slots.
+    user_template: |
+      Message:
+      - text: {text}
+      - urls: {urls}
+      - attachments: {attachments}
+      - locale: {locale}, tz: {timezone}
+      Session snapshot:
+      - last_url: {last_url}
+      - last_file: {last_file}
+      - last_intent_hint: {last_intent_hint}
+      Families gated: {families}
+      List up to {topK} intents.
+    output_schema_hint: "List[{intent: string, rationale: string}]"
+
+  slotfill_extract_v1:
+    system: |
+      You extract ONLY the missing fields required to execute the given intent.
+      Use the current user message, the message envelope, and a short memory snapshot.
+      Do not invent values. If unsure, leave the field absent.
+      Output strictly the JSON schema in "json_schema_hint".
+    user_template: |
+      Intent: {intent}
+      Required fields (missing): {missing_fields}
+      Allowed extra context:
+      - message.text: {text}
+      - urls: {urls}
+      - attachments_meta: {attachments_meta}
+      - locale/tz: {locale} / {timezone}
+      - memory.short_ctx: {short_ctx}
+      - memory.entity_bag: {entity_bag}
+      - stickies: {stickies}
+
+      Return only fields you are confident about. Provide per-field confidence 0..1.
+    json_schema_hint: |
+      {
+        "type": "object",
+        "properties": {
+          "fields":  { "type":"object", "additionalProperties": true },
+          "confidence": { "type":"number" },
+          "field_confidence": { "type":"object", "additionalProperties": { "type":"number" } }
+        },
+        "required": ["fields","confidence","field_confidence"]
+      }
+
+  slotfill_verify_v1:
+    system: |
+      You verify a candidate field set for the given intent.
+      Judge plausibility, internal consistency, and whether values match the intent's semantics.
+      No regex or external lookup; rely on reasoning and the context provided.
+      If a field appears ill-formed or ambiguous, mark valid=false and explain briefly.
+    user_template: |
+      Intent: {intent}
+      Candidate fields: {fields}
+      Context text: {text}
+      Memory.short_ctx: {short_ctx}
+
+      Return JSON: {"valid": boolean, "why": string, "overall_confidence": number,
+                    "per_field": {"<field>": {"valid": boolean, "confidence": number, "why": string}}}
+
+  ask_missing_v1:
+    system: |
+      Ask the user for exactly one missing field. Be concise and friendly.
+      Use locale and friendly label if available. Do not include any other content.
+    user_template: |
+      locale: {locale}
+      field: {field}
+      friendly_label: {friendly_label}
+
+      # Expected output: short question text
+
+  confirm_action_v1:
+    system: |
+      Ask for an explicit confirmation before executing a sensitive action.
+      If double-confirm is requested, instruct the user to reply with the exact phrase.
+      Be brief and clear.
+    user_template: |
+      locale: {locale}
+      intent: {intent}
+      summary: {summary}
+      double_confirm_phrase: {double_confirm_phrase}

--- a/registry/capability_matrix.yaml
+++ b/registry/capability_matrix.yaml
@@ -1,1 +1,80 @@
-capabilities: []
+version: "2025-03-01"
+agents:
+  media_agent:
+    families: ["video","music","media"]
+    intents_supported:
+      - "video.thumbnail"
+      - "video.gif"
+      - "music.send"
+      - "music.preview"
+      - "music.normalize"
+      - "music.convert"
+    resources:
+      accepts:
+        source: ["file_id","url"]
+      media_types:
+        video: ["video/mp4","video/webm","video/quicktime"]
+        audio: ["audio/mpeg","audio/wav","audio/flac","audio/aac"]
+      caps:
+        max_bytes: 500000000
+        max_duration_s: 7200
+    concurrency:
+      max_inflight: 32
+
+  vision_agent:
+    families: ["images","ocr","qr","barcode","table"]
+    intents_supported:
+      - "image.describe"
+      - "image.remove_bg"
+      - "image.face_blur"
+      - "doc.ocr"
+      - "qr.decode"
+      - "barcode.decode"
+      - "table.extract"
+    resources:
+      accepts:
+        image: ["image/jpeg","image/png","image/webp"]
+        document: ["application/pdf"]
+      caps:
+        max_pixels: 268435456
+        pdf_max_pages: 30
+    concurrency:
+      max_inflight: 24
+
+  markets_agent:
+    families: ["finance"]
+    intents_supported:
+      - "finance.crypto.ticker"
+      - "finance.fx.convert"
+      - "finance.fx.rate"
+      - "finance.crypto.ohlc"
+    resources:
+      accepts:
+        source: ["text"]
+      caps: {}
+    concurrency:
+      max_inflight: 64
+
+  calendar_agent:
+    families: ["schedule"]
+    intents_supported: ["sched.book","sched.reschedule","sched.cancel","sched.slots"]
+    resources:
+      accepts: { source: ["text"] }
+    concurrency:
+      max_inflight: 16
+
+  network_agent:
+    families: ["network"]
+    intents_supported: ["network.proxy.get","vpn.recommend"]
+    resources:
+      accepts: { source: ["text"] }
+    concurrency:
+      max_inflight: 16
+
+  nlp_agent:
+    families: ["core","text"]
+    intents_supported: ["chat.general","text.summarize","text.translate"]
+    resources:
+      accepts: { source: ["text"] }
+    concurrency:
+      max_inflight: 128

--- a/registry/route_registry.yaml
+++ b/registry/route_registry.yaml
@@ -1,1 +1,151 @@
-routes: []
+families:
+  core:
+    modal_requirements: []
+    intents_ref: core_intents
+  media:
+    modal_requirements: ["url|file"]
+    intents_ref: media_intents
+  images:
+    modal_requirements: ["file|url"]
+    intents_ref: image_intents
+  video:
+    modal_requirements: ["file|url"]
+    intents_ref: video_intents
+  ocr:
+    modal_requirements: ["file"]
+    intents_ref: ocr_intents
+  qr:
+    modal_requirements: ["file|text"]
+    intents_ref: qr_intents
+  barcode:
+    modal_requirements: ["file|text"]
+    intents_ref: barcode_intents
+  table:
+    modal_requirements: ["file|url"]
+    intents_ref: table_intents
+  schedule:
+    modal_requirements: ["text"]
+    intents_ref: schedule_intents
+  network:
+    modal_requirements: ["text"]
+    intents_ref: network_intents
+  finance:
+    modal_requirements: ["text"]
+    intents_ref: finance_intents
+  music:
+    modal_requirements: ["file|id|url"]
+    intents_ref: music_intents
+  doc:
+    modal_requirements: ["file"]
+    intents_ref: doc_intents
+
+intents:
+  core_intents:
+    - name: "core.help"
+      desc: "Show help information"
+    - name: "core.menu"
+      desc: "Show menu options"
+    - name: "core.settings"
+      desc: "Open settings"
+    - name: "core.language.set"
+      desc: "Change interface language"
+    - name: "chat.general"
+      desc: "General chat"
+  media_intents:
+    - name: "media.transcript"
+      desc: "Get transcript of a video or audio"
+    - name: "media.chapters"
+      desc: "Create chapters for media"
+    - name: "media.highlights"
+      desc: "Highlight key moments"
+    - name: "media.quotes"
+      desc: "Extract notable quotes"
+    - name: "link.screenshot"
+      desc: "Capture screenshot of a webpage"
+  image_intents:
+    - name: "image.generate"
+      desc: "Generate an image from text"
+    - name: "image.describe"
+      desc: "Describe an image"
+    - name: "image.remove_bg"
+      desc: "Remove background from image"
+    - name: "image.face_blur"
+      desc: "Blur faces in an image"
+    - name: "image.annotate"
+      desc: "Annotate an image"
+    - name: "image.background_replace"
+      desc: "Replace image background"
+  video_intents:
+    - name: "video.thumbnail"
+      desc: "Extract thumbnail at given timestamp"
+    - name: "video.gif"
+      desc: "Create GIF from video clip"
+  ocr_intents:
+    - name: "doc.ocr"
+      desc: "OCR a document"
+    - name: "doc.parse_invoice"
+      desc: "Parse invoice fields"
+    - name: "doc.qa"
+      desc: "Question answering over document"
+    - name: "receipt.extract"
+      desc: "Extract fields from receipt"
+  qr_intents:
+    - name: "qr.generate"
+      desc: "Generate QR code"
+    - name: "qr.decode"
+      desc: "Decode QR code"
+  barcode_intents:
+    - name: "barcode.decode"
+      desc: "Decode barcode"
+  table_intents:
+    - name: "table.extract"
+      desc: "Extract table to CSV"
+  schedule_intents:
+    - name: "sched.book"
+      desc: "Book a meeting"
+    - name: "sched.reschedule"
+      desc: "Reschedule a meeting"
+    - name: "sched.cancel"
+      desc: "Cancel a booking"
+    - name: "sched.slots"
+      desc: "Show available slots"
+  network_intents:
+    - name: "network.proxy.get"
+      desc: "Get proxy server"
+    - name: "vpn.recommend"
+      desc: "Recommend VPN"
+  finance_intents:
+    - name: "finance.crypto.ticker"
+      desc: "Get crypto price"
+    - name: "finance.crypto.ohlc"
+      desc: "Get crypto OHLC data"
+    - name: "finance.fx.rate"
+      desc: "Get FX rate"
+    - name: "finance.fx.convert"
+      desc: "Convert currency"
+  music_intents:
+    - name: "music.send"
+      desc: "Send an audio track to recipient"
+    - name: "music.preview"
+      desc: "Create audio preview"
+    - name: "music.normalize"
+      desc: "Normalize audio loudness"
+    - name: "music.convert"
+      desc: "Convert audio format"
+    - name: "music.clip"
+      desc: "Clip audio segment"
+    - name: "music.playlist.create"
+      desc: "Create playlist"
+    - name: "music.playlist.add"
+      desc: "Add track to playlist"
+    - name: "music.playlist.remove"
+      desc: "Remove track from playlist"
+    - name: "music.inline.search"
+      desc: "Search for tracks"
+  doc_intents:
+    - name: "doc.ocr"
+      desc: "OCR document"
+    - name: "doc.parse_invoice"
+      desc: "Parse invoice"
+    - name: "doc.qa"
+      desc: "QA on document"

--- a/registry/semantic_corpus.yaml
+++ b/registry/semantic_corpus.yaml
@@ -1,1 +1,330 @@
-corpus: []
+semantic_corpus:
+  languages: ["en", "fa"]
+
+  domain_utterances:
+    core:
+      - "help"
+      - "menu"
+      - "settings"
+      - "change language to persian"
+      - "change language to english"
+      - "راهنما"
+      - "منو"
+      - "تنظیمات"
+      - "زبان را فارسی کن"
+      - "زبان را انگلیسی کن"
+      - "TL;DR this text"
+      - "summarize this"
+      - "translate to persian"
+      - "fix grammar"
+      - "خلاصه کن"
+      - "به فارسی ترجمه کن"
+      - "اشتباهات گرامر را اصلاح کن"
+    media:
+      - "summarize this youtube link"
+      - "get transcript of this video"
+      - "create chapters"
+      - "highlights of this clip"
+      - "notable quotes"
+      - "این لینک را خلاصه کن"
+      - "متن این ویدیو را بگیر"
+      - "فصل‌بندی ویدیو"
+      - "نکات کلیدی"
+      - "جملات مهم"
+    images:
+      - "generate an image"
+      - "describe this image"
+      - "remove background"
+      - "blur faces"
+      - "تصویر بساز"
+      - "این تصویر را توصیف کن"
+      - "حذف پس‌زمینه"
+      - "تاری چهره‌ها"
+    tutor:
+      - "start language tutor"
+      - "correct my text with explanations"
+      - "roleplay at a hotel"
+      - "آموزش زبان را شروع کن"
+      - "با توضیح اصلاح کن"
+      - "نقش‌آفرینی در هتل"
+    schedule:
+      - "show available slots"
+      - "book 2025-08-26 14:00 for 30 minutes"
+      - "reschedule my meeting"
+      - "cancel booking ABC123"
+      - "زمان‌های خالی را نشان بده"
+      - "رزرو 2025-08-26 ساعت 14:00"
+      - "جلسه را جابجا کن"
+      - "لغو رزرو ABC123"
+    utilities:
+      - "BTCUSD price now"
+      - "ETH/USDT 1h OHLC"
+      - "fx rate usd to eur"
+      - "convert 120 usd to eur"
+      - "قیمت بیت کوین"
+      - "کندل‌های ۱ ساعته ETH/USDT"
+      - "نرخ دلار به یورو"
+      - "تبدیل ۱۲۰ دلار به یورو"
+      - "generate qr for this text"
+      - "decode this barcode"
+      - "برای این متن QR بساز"
+      - "این بارکد را بخوان"
+      - "استخراج متن از سند"
+      - "VPN for streaming to US"
+      - "socks5 proxy for UK"
+      - "vpn برای نتفلیکس آمریکا"
+      - "پروکسی socks5 برای آلمان"
+    other:
+      - "hi"
+      - "general chat"
+      - "help me"
+      - "سلام"
+      - "گپ"
+
+  utterances_by_intent:
+    core.help:
+      positives: ["help", "help me", "what can you do"]
+      negatives: ["settings","menu","language fa","language english"]
+    core.menu:
+      positives: ["menu","show menu","open menu"]
+      negatives: ["help","settings","language"]
+    core.settings:
+      positives: ["settings","open settings"]
+      negatives: ["help","menu","language"]
+    core.language.set:
+      positives: ["change language to english","change language to persian","language fa","language en"]
+      negatives: ["help","menu","settings"]
+    chat.general:
+      positives: ["hi","hello","سلام","گپ بزنیم"]
+      negatives: ["menu","settings","help"]
+    link.screenshot:
+      positives:
+        - "screenshot this page"
+        - "full page screenshot"
+        - "capture webpage snapshot"
+        - "اسکرین‌شات از این لینک"
+        - "اسکرین شات کامل صفحه"
+      negatives: ["summarize this link","translate this page","SEO meta"]
+    video.thumbnail:
+      positives:
+        - "thumbnail at 5s"
+        - "grab frame at 00:00:05"
+        - "poster frame at 12s"
+        - "get still frame"
+        - "تصویر بندانگشتی در ۵ ثانیه"
+      negatives: ["gif","animated","loop"]
+    video.gif:
+      positives:
+        - "gif 00:00:02 to 00:00:05"
+        - "make a gif from 5s to 25s"
+        - "animated gif clip"
+        - "looping gif"
+        - "ساخت گیف ۵ تا ۲۵ ثانیه"
+      negatives: ["thumbnail","poster frame","still image"]
+    media.transcript:
+      positives:
+        - "get transcript of this Vimeo"
+        - "transcribe this TikTok"
+        - "extract captions from YouTube"
+        - "متن این ویدیو را بگیر"
+      negatives: ["screenshot this page"]
+    media.chapters:
+      positives:
+        - "get chapters for this video"
+        - "chapterize this YouTube"
+        - "create sections with timestamps"
+        - "فصل‌بندی ویدیو"
+      negatives: ["quotes","highlights"]
+    media.highlights:
+      positives:
+        - "highlight key moments in this video"
+        - "best moments"
+        - "نکات کلیدی ویدیو"
+      negatives: ["chapters","quotes"]
+    media.quotes:
+      positives:
+        - "notable quotes from this video"
+        - "pull the best quotes"
+        - "extract key quotes"
+        - "جملات مهم ویدیو"
+      negatives: ["chapters","highlights"]
+    image.generate:
+      positives:
+        - "generate an image of a cyberpunk city at night"
+        - "create AI art"
+        - "text-to-image"
+        - "تصویر بساز"
+      negatives: ["describe this image","remove background","blur faces"]
+    image.describe:
+      positives:
+        - "describe this image"
+        - "what's in the picture"
+        - "caption this photo"
+        - "این تصویر را توصیف کن"
+      negatives: ["generate an image","remove background","blur faces"]
+    image.remove_bg:
+      positives:
+        - "remove background"
+        - "erase background"
+        - "transparent background"
+        - "حذف پس‌زمینه"
+      negatives: ["replace background with","describe this image","blur faces"]
+    image.face_blur:
+      positives:
+        - "blur faces for privacy"
+        - "pixelate faces"
+        - "hide all faces"
+        - "تاری چهره برای حفظ حریم خصوصی"
+      negatives: ["remove background","describe image","variation"]
+    image.annotate:
+      positives:
+        - "add a red circle around the main object"
+        - "draw arrow and label"
+        - "highlight the main object"
+        - "دایرهٔ قرمز دور سوژه"
+      negatives: ["remove background","blur faces","variation only"]
+    image.background_replace:
+      positives:
+        - "replace background with a modern office"
+        - "swap the background to a beach"
+        - "change background to white studio"
+        - "تعویض پس‌زمینه با دفتر مدرن"
+      negatives: ["remove background only","describe this image"]
+    music.send:
+      positives:
+        - "send 'Perfect' by Ed Sheeran to my email"
+        - "email 'Blinding Lights' to sara@example.com"
+        - "text the song to +1 415 555 0100"
+        - "DM 'Viva La Vida' to @mona"
+        - "«چرا رفتی» رو برای مریم ایمیل کن"
+        - "این آهنگ رو به تلگرامم بفرست"
+      negatives: ["send screenshot","send pdf","share playlist screenshot"]
+    music.preview:
+      positives:
+        - "make a 20s preview"
+        - "30s preview please"
+        - "پیش‌نمایش ۳۰ ثانیه‌ای بساز"
+      negatives: ["video thumbnail","create gif"]
+    music.normalize:
+      positives:
+        - "normalize to -14 lufs"
+        - "match loudness"
+        - "تنظیم لودنس به -۱۴ LUFS"
+      negatives: ["convert to mp3","trim clip","make preview"]
+    music.convert:
+      positives:
+        - "convert to mp3 320kbps"
+        - "export to wav"
+        - "encode aac 256kbps"
+        - "تبدیل به mp3 320kbps"
+      negatives: ["convert pdf to docx","image to png"]
+    music.clip:
+      positives:
+        - "clip 00:00:05 to 00:00:25 with fade"
+        - "trim 5s–25s"
+        - "کلیپ ۵ تا ۲۵ ثانیه"
+      negatives: ["video clip edit","gif from video"]
+    music.playlist.create:
+      positives:
+        - "create playlist \"Gym Mix 2025\""
+        - "new playlist: Sunday Chill"
+        - "ساخت پلی‌لیست: یکشنبه‌های آروم"
+      negatives: ["create calendar","create task list"]
+    music.playlist.add:
+      positives:
+        - "add TRK-123 to playlist Gym Mix 2025"
+        - "put this song into Sunday Chill"
+        - "افزودن ترک ۴۵۶ به پلی‌لیست سفر"
+      negatives: ["add item to todo list","append to csv"]
+    music.playlist.remove:
+      positives:
+        - "remove TRK-123 from playlist PLAY-777"
+        - "take this song out of Sunday Chill"
+        - "حذف آهنگ از پلی‌لیست «باشگاه»"
+      negatives: ["remove background","remove proxy"]
+    music.inline.search:
+      positives:
+        - "songs by Radiohead"
+        - "tracks by Taylor Swift"
+        - "music from Coldplay"
+        - "آهنگ‌های شجریان"
+      negatives: ["web search news","google images","vpn proxy list"]
+    qr.generate:
+      positives:
+        - "generate QR for https://example.com"
+        - "create QR for سلام دنیا"
+        - "make a QR code"
+      negatives: ["scan qr","decode qr"]
+    qr.decode:
+      positives: ["decode this QR","scan this QR","read the QR code"]
+      negatives: ["generate qr","make qr code"]
+    barcode.decode:
+      positives: ["decode this barcode","scan barcode","read UPC/EAN"]
+      negatives: ["generate qr","make qr code"]
+    table.extract:
+      positives: ["extract table as CSV","convert table to csv","جدول را به CSV تبدیل کن"]
+      negatives: ["normalize table schema","database table design"]
+    receipt.extract:
+      positives: ["parse invoice fields","extract receipt fields","فیلدهای رسید را استخراج کن"]
+      negatives: ["ocr only","translate this document"]
+    doc.ocr:
+      positives:
+        - "OCR this file"
+        - "extract text from PDF"
+        - "recognize text from image"
+        - "استخراج متن از سند"
+      negatives: ["parse invoice fields","what is the total amount"]
+    doc.parse_invoice:
+      positives: ["parse invoice fields","extract invoice data","فیلدهای فاکتور را استخراج کن"]
+      negatives: ["ocr only","translate document"]
+    doc.qa:
+      positives:
+        - "what is the total amount?"
+        - "what's the tax amount?"
+        - "due date?"
+        - "مبلغ کل چقدر است؟"
+      negatives: ["ocr this","parse invoice fields"]
+    network.proxy.get:
+      positives:
+        - "socks5 proxy for DE"
+        - "http proxy to UK"
+        - "MTProto proxy"
+        - "proxy server for gaming"
+        - "پروکسی socks5 برای آلمان"
+      negatives:
+        - "proxy brush in photoshop"
+        - "design pattern proxy"
+        - "photoshop proxy settings"
+    vpn.recommend:
+      positives:
+        - "VPN for streaming to US"
+        - "vpn نتفلیکس آمریکا"
+        - "vpn برای استریم"
+      negatives:
+        - "vpn upload speed test"
+        - "corporate vpn policy"
+    finance.crypto.price:
+      positives:
+        - "price BTCUSD now"
+        - "BTC/USDT price"
+        - "what's BTC price"
+        - "current price of ETH"
+      negatives: ["candles","ohlc","convert","ticket price","pricing page"]
+    finance.crypto.ohlc:
+      positives:
+        - "BTCUSD 4h candles"
+        - "ETH/USDT 15m ohlc"
+        - "daily candle chart"
+      negatives: ["price now","convert","rate","ticker"]
+    finance.fx.rate:
+      positives:
+        - "usd to eur rate"
+        - "eur/usd rate"
+        - "fx rate usd eur"
+      negatives: ["convert 120 usd to eur","ohlc","crypto"]
+    finance.fx.convert:
+      positives:
+        - "convert 120 usd to eur"
+        - "usd -> eur convert amount"
+        - "تبدیل ۱۲۰ دلار به یورو"
+      negatives: ["rate","ohlc","price","ticket price"]

--- a/specs/task_specs.yaml
+++ b/specs/task_specs.yaml
@@ -1,1 +1,75 @@
-tasks: []
+version: "2025-03-01"
+tasks:
+  - name: "video.thumbnail"
+    family: "video"
+    version: "1.0.0"
+    description: "Extract a poster frame at timestamp from a video (url or file)."
+    inputs:
+      required: ["at", "source"]
+      optional: ["size"]
+      types:
+        at: "timecode"
+        source: "file_id|url"
+        size: "enum[256,512,768,1024]"
+    resources:
+      needs: ["video_source"]
+    produces:
+      - { key: "image_file_id", type: "file_id" }
+    side_effects: false
+    default_agent: "media_agent"
+
+  - name: "video.gif"
+    family: "video"
+    version: "1.0.0"
+    description: "Create a GIF clip from a video, with start and end times."
+    inputs:
+      required: ["start","end","source"]
+      optional: ["fps","size","caption"]
+      types:
+        start: "timecode"
+        end: "timecode"
+        source: "file_id|url"
+        fps: "int"
+        size: "enum[256,512,768]"
+        caption: "string"
+    resources:
+      needs: ["video_source"]
+    produces:
+      - { key: "gif_file_id", type: "file_id" }
+    side_effects: false
+    default_agent: "media_agent"
+
+  - name: "music.send"
+    family: "music"
+    version: "1.1.0"
+    description: "Send an audio track to a recipient (email/phone/@handle)."
+    inputs:
+      required: ["recipient","track_source"]
+      optional: ["message"]
+      types:
+        recipient: "email|phone|handle"
+        track_source: "file_id|id|url"
+        message: "string"
+    resources:
+      needs: ["audio_source"]
+    produces: []
+    side_effects: true
+    default_agent: "media_agent"
+
+  - name: "doc.ocr"
+    family: "ocr"
+    version: "1.0.0"
+    description: "OCR an image/PDF document."
+    inputs:
+      required: ["file_id"]
+      optional: ["language","as_markdown"]
+      types:
+        file_id: "file_id"
+        language: "lang"
+        as_markdown: "bool"
+    resources:
+      needs: ["image_or_pdf"]
+    produces:
+      - { key: "text", type: "string" }
+    side_effects: false
+    default_agent: "vision_agent"

--- a/stack/stack.yaml
+++ b/stack/stack.yaml
@@ -1,1 +1,215 @@
-services: []
+stack:
+  name: "assist-stack"
+  version: "2025.03"
+  environment: "prod"
+  region: "eu-west-1"
+  release_id: "${GIT_SHA}"
+  clock: "utc"
+
+  schemas:
+    chat_adapter: "ChatAdapterConfig@1"
+    router: "RouterConfig@1"
+    orchestrator: "AOROrchestratorConfig@1"
+    dispatch_controller: "DispatchControllerConfig@1"
+    simple_dispatcher: "SimpleDispatcherConfig@1"
+    route_registry: "RouteRegistry@1"
+    prompts: "PromptsPack@1"
+    capability_matrix: "CapabilityMatrix@1"
+    task_specs: "TaskSpecs@1"
+    safety_bundle: "OPABundle@1"
+    pii_rules: "PIIPolicy@1"
+    semantic_corpus: "SemanticCorpus@1"
+
+  uris:
+    configs:
+      chat_adapter: "s3://assist/config/v1/chat_adapter.yaml"
+      router: "s3://assist/config/v1/router.yaml"
+      orchestrator: "s3://assist/config/v1/orchestrator.yaml"
+      dispatch_controller: "s3://assist/config/v1/dispatch_controller.yaml"
+      simple_dispatcher: "s3://assist/config/v1/simple_dispatcher.yaml"
+    registries:
+      route_registry: "s3://assist/registry/v3/route_registry.yaml"
+      capability_matrix: "s3://assist/registry/v2/capability_matrix.yaml"
+      semantic_corpus: "s3://assist/registry/v1/semantic_corpus.yaml"
+    prompts:
+      pack: "s3://assist/prompts/v4/prompts.yaml"
+    models:
+      llm_router: "alias://models/llm/router"
+      llm_slotfill: "alias://models/llm/slotfill"
+      llm_recall: "alias://models/llm/recall"
+      llm_memory_sum: "alias://models/llm/memory_summarizer"
+      cross_encoder: "alias://models/retrieval/cross_encoder"
+      embed_intent: "alias://models/embeddings/intent"
+    indices:
+      faiss_intents_v1: "faiss://intents-v1"
+    calibration:
+      isotonic_tables_v1: "s3://assist/ranker/calibration/isotonic_v1.json"
+    ltr:
+      weights_v1: "s3://assist/ranker/ltr/weights_v1.json"
+    safety:
+      opa_bundle: "s3://assist/policy/opa/bundle-v2.tar.gz"
+      pii_rules: "s3://assist/policy/pii/pii_rules_v1.json"
+    storage:
+      artifacts_bucket: "s3://assist-artifacts"
+      logs_bucket: "s3://assist-logs"
+    secrets:
+      media_agent_token: "vault://kv/agents/media"
+      vision_agent_token: "vault://kv/agents/vision"
+      markets_agent_token: "vault://kv/agents/markets"
+      calendar_agent_token: "vault://kv/agents/calendar"
+      network_agent_token: "vault://kv/agents/network"
+      nlp_agent_token: "vault://kv/agents/nlp"
+      root_ca_bundle: "vault://kv/security/root_ca_bundle"
+      artifacts_kms_key: "vault://kv/kms/artifacts_sse"
+
+  models:
+    providers:
+      openai:
+        api: "https://api.openai.com"
+      huggingface:
+        api: "https://inference.huggingface.co"
+      local:
+        api: "http://llm-gateway.internal"
+    llm:
+      router: { provider: "openai", model_id: "gpt-5-nano" }
+      slotfill: { provider: "openai", model_id: "gpt-5-nano" }
+      recall: { provider: "openai", model_id: "gpt-5-nano" }
+      memory_summarizer: { provider: "openai", model_id: "gpt-5-nano" }
+    retrieval:
+      cross_encoder: { provider: "huggingface", model_id: "mini-cross-encoder-msmarco" }
+    embeddings:
+      intent: { provider: "openai", model_id: "text-embedding-3-large", normalize: true }
+
+  security:
+    secrets:
+      provider: "vault"
+      mount: "kv/"
+    tls:
+      verify_peer: true
+      root_ca_ref: "*uris.secrets.root_ca_bundle"
+
+  feature_flags:
+    enable_lexical_ranker: false
+    enable_llm_recall: true
+    llm_recall_allowed_families: ["music","video","media","schedule","network","finance"]
+    enable_memory_rerank: true
+    router_log_debug: true
+    dispatch_autoslot_llm: true
+    planner_allow_bridges: true
+    planner_validate_policy: true
+
+  bindings:
+    router:
+      set:
+        "models.dense_sr.embedder": "@models.embeddings.intent"
+        "models.dense_sr.index_uri": "@uris.indices.faiss_intents_v1"
+        "models.llm_recall.model": "@models.llm.recall"
+        "models.memory_summarizer.model": "@models.llm.memory_summarizer"
+        "models.cross_encoder.model": "@models.retrieval.cross_encoder.model_id"
+        "ranker.precision_rerank.calibration.table_uri": "@uris.calibration.isotonic_tables_v1"
+        "ranker.precision_rerank.ltr_blend.model_uri": "@uris.ltr.weights_v1"
+        "models.calibrator.table_uri": "@uris.calibration.isotonic_tables_v1"
+        "runtime.trace_enabled": "@feature_flags.router_log_debug"
+        "ranker.candidate_generation.llm_recall.enabled": "@feature_flags.enable_llm_recall"
+        "ranker.precision_rerank.enabled": "@feature_flags.enable_memory_rerank"
+    chat_adapter:
+      set:
+        "runtime.trace_enabled": true
+        "defaults.target_lang": "fa"
+        "storage.artifacts.base_uri": "@uris.storage.artifacts_bucket"
+        "security.tls.root_ca_ref": "@uris.secrets.root_ca_bundle"
+    orchestrator:
+      set:
+        "artifacts.base_uri": "@uris.storage.artifacts_bucket"
+        "policy.opa_bundle_uri": "@uris.safety.opa_bundle"
+        "pii.redaction_rules_uri": "@uris.safety.pii_rules"
+    dispatch_controller:
+      set:
+        "slotfill_llm.model": "@models.llm.slotfill"
+        "prompts.uri": "@uris.prompts.pack"
+        "capability_matrix.uri": "@uris.registries.capability_matrix"
+        "policy.opa_bundle_uri": "@uris.safety.opa_bundle"
+        "pii.redaction_rules_uri": "@uris.safety.pii_rules"
+        "feature_flags.dispatch_autoslot_llm": "@feature_flags.dispatch_autoslot_llm"
+    simple_dispatcher:
+      set:
+        "artifacts.store.base_uri": "@uris.storage.artifacts_bucket"
+        "artifacts.store.sse_kms_key_ref": "@uris.secrets.artifacts_kms_key"
+        "security.tls.root_ca_ref": "@uris.secrets.root_ca_bundle"
+        "endpoints.media_agent.auth.secret_ref": "@uris.secrets.media_agent_token"
+        "endpoints.vision_agent.auth.secret_ref": "@uris.secrets.vision_agent_token"
+        "endpoints.markets_agent.auth.secret_ref": "@uris.secrets.markets_agent_token"
+        "endpoints.calendar_agent.auth.secret_ref": "@uris.secrets.calendar_agent_token"
+        "endpoints.network_agent.auth.secret_ref": "@uris.secrets.network_agent_token"
+        "endpoints.nlp_agent.auth.secret_ref": "@uris.secrets.nlp_agent_token"
+    route_registry:
+      set:
+        "source_uri": "@uris.registries.route_registry"
+    prompts:
+      set:
+        "source_uri": "@uris.prompts.pack"
+    semantic_corpus:
+      set:
+        "source_uri": "@uris.registries.semantic_corpus"
+
+  observability:
+    logging:
+      level: "INFO"
+      json: true
+    metrics:
+      exporter: "prometheus"
+      scrape_port: 9400
+    tracing:
+      exporter: "otlp"
+      endpoint: "http://otel-collector:4317"
+      sample_ratio: 0.1
+
+  health:
+    preflight_checks:
+      - type: "s3_exists"; uri: "@uris.configs.router"
+      - type: "s3_exists"; uri: "@uris.configs.chat_adapter"
+      - type: "s3_exists"; uri: "@uris.registries.route_registry"
+      - type: "faiss_open"; uri: "@uris.indices.faiss_intents_v1"
+      - type: "http_head"; uri: "@models.providers.openai.api"
+    readiness:
+      router_warmup:
+        load_prompts: "@uris.prompts.pack"
+        load_registry: "@uris.registries.route_registry"
+        open_faiss: "@uris.indices.faiss_intents_v1"
+
+  reload:
+    enabled: true
+    watch:
+      - "@uris.configs.router"
+      - "@uris.configs.dispatch_controller"
+      - "@uris.registries.route_registry"
+      - "@uris.prompts.pack"
+      - "@uris.calibration.isotonic_tables_v1"
+      - "@uris.ltr.weights_v1"
+    strategy: "safe_swap"
+
+  tenants:
+    - id: "default"
+      locale: "fa-IR"
+      tz: "Europe/Amsterdam"
+      caps:
+        stt_max_min: 30
+      overrides:
+        feature_flags.enable_llm_recall: true
+    - id: "enterprise-A"
+      locale: "en-US"
+      tz: "America/New_York"
+      overrides:
+        models.llm.router.model_id: "gpt-5-nano"
+        policy.third_party_scrape: "deny"
+
+  checksums:
+    router: "sha256:5a7a...e9"
+    chat_adapter: "sha256:9fd1...ab"
+    orchestrator: "sha256:44cc...1b"
+    dispatch_controller: "sha256:b212...c9"
+    simple_dispatcher: "sha256:b01d...df"
+    route_registry: "sha256:fe88...00"
+    prompts: "sha256:0a6e...aa"
+    calibration: "sha256:1f21...be"
+    ltr_weights: "sha256:f0d2...77"


### PR DESCRIPTION
## Summary
- add detailed ChatAdapter config with preprocessing, locale, stickies, and hints
- implement LLM-driven router, orchestrator, and dispatch controller settings
- include capability matrix, route registry, semantic corpus, prompts, task specs, and stack manifest wiring

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'apps')*

------
https://chatgpt.com/codex/tasks/task_e_68afcf5312b883329cf1e046c85a33cc