### PR TITLE
Replace monolithic stubs with modular services

### DIFF
--- a/apps/chat_adapter/__init__.py
+++ b/apps/chat_adapter/__init__.py
@@ -1,1 +1,61 @@
-"""Chat adapter service."""
+"""Chat adapter service.
+
+This module exposes a tiny :class:`ChatAdapter` class that mirrors the public
+API of the much larger production component.  The adapter normalises incoming
+messages and delegates to the orchestrator which in turn talks to the router.
+
+Only a very small subset of the real behaviour is implemented – just enough
+for the tests in this kata.  The structure however matches the architecture
+described in the configuration files allowing the stand‑ins to be replaced by
+fully fledged implementations without changing the HTTP layer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from lib.contracts.envelope import MessageEnvelope
+from lib.config.yaml_loader import load_yaml
+
+from .service import normalize_message
+
+
+@dataclass
+class ChatAdapter:
+    """Light‑weight chat adapter used in the examples.
+
+    Parameters
+    ----------
+    orchestrator:
+        Instance of :class:`apps.orchestrator.Orchestrator` that turns normalised
+        envelopes into AOR structures.  The object is kept deliberately small so
+        the focus of the exercises can remain on the wiring rather than complex
+        business logic.
+    """
+
+    orchestrator: Any
+    config: Any | None = field(default=None)
+    config_path: str = "config/chat_adapter.yaml"
+
+    def __post_init__(self) -> None:
+        if self.config is None and Path(self.config_path).exists():
+            self.config = load_yaml(self.config_path)
+
+    def handle_user_update(self, chat_id: str, user_id: str, *, text: str = "") -> Any:
+        """Normalise the message and forward it to the orchestrator.
+
+        The return value is whatever structure the orchestrator produces.  In
+        the real project this would include dispatch decisions and telemetry
+        data.  For the purposes of the unit tests we simply return the
+        orchestrator result directly.
+        """
+
+        envelope_dict = normalize_message({"text": text})
+        envelope = MessageEnvelope(message=envelope_dict.get("text", ""))
+        return self.orchestrator.process_user_input(chat_id, envelope.message)
+
+
+__all__ = ["ChatAdapter"]
+

--- a/apps/chat_adapter/main.py
+++ b/apps/chat_adapter/main.py
@@ -1,8 +1,30 @@
-from fastapi import FastAPI
+"""HTTP entry point for the chat adapter.
 
+The adapter glues together the router and orchestrator to form the public
+interface used by clients.  This version uses the light‑weight stand‑ins from
+the :mod:`apps` packages rather than the monolithic prototype.
+"""
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from apps.chat_adapter import ChatAdapter
+from apps.orchestrator import Orchestrator
+from apps.router import Router
+
+
+router = Router()
+orchestrator = Orchestrator(router)
+adapter = ChatAdapter(orchestrator)
 app = FastAPI()
 
+
+class IngestRequest(BaseModel):
+    text: str = ""
+
+
 @app.post("/ingest")
-async def ingest():
-    """Ingest a message envelope."""
-    return {"status": "ok"}
+async def ingest(req: IngestRequest):
+    """Ingest a message envelope and return the resulting AOR."""
+
+    return adapter.handle_user_update("chat", "user", text=req.text)

--- a/apps/orchestrator/__init__.py
+++ b/apps/orchestrator/__init__.py
@@ -1,1 +1,43 @@
-"""Orchestrator service."""
+"""Orchestrator service.
+
+The orchestrator receives a plan skeleton from the router and wraps it in an
+``AOR`` (Action Oriented Response) object.  Only minimal functionality is
+implemented which keeps the module light weight while still demonstrating the
+flow through the architecture.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from lib.contracts.aor import AOR
+from lib.config.yaml_loader import load_yaml
+
+from . import builder, idempotency
+
+
+@dataclass
+class Orchestrator:
+    """Compile router output into an :class:`~lib.contracts.aor.AOR` instance."""
+
+    router: Any
+    config: Any | None = field(default=None)
+    config_path: str = "config/orchestrator.yaml"
+
+    def __post_init__(self) -> None:
+        if self.config is None and Path(self.config_path).exists():
+            self.config = load_yaml(self.config_path)
+
+    def process_user_input(self, session_id: str, text: str) -> AOR:
+        """Run the routing stage and build an ``AOR`` structure."""
+
+        plan = self.router.route(text)
+        nodes = builder.build_nodes(plan.model_dump())
+        ensured = idempotency.ensure_idempotent(nodes)
+        return AOR(steps=ensured.get("routes", []))
+
+
+__all__ = ["Orchestrator"]
+

--- a/apps/orchestrator/main.py
+++ b/apps/orchestrator/main.py
@@ -1,8 +1,28 @@
-from fastapi import FastAPI
+"""Expose the orchestrator over HTTP.
 
+The implementation delegates to the light‑weight :class:`apps.orchestrator.Orchestrator`
+which itself relies on :class:`apps.router.Router`.  Both classes are minimal
+but mirror the public API of the production services.
+"""
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from apps.orchestrator import Orchestrator
+from apps.router import Router
+
+
+router = Router()
+orchestrator = Orchestrator(router)
 app = FastAPI()
 
+
+class AORRequest(BaseModel):
+    text: str = ""
+
+
 @app.post("/aor")
-async def aor():
-    """Return AOR."""
-    return {"aor": []}
+async def aor(req: AORRequest):
+    """Return an AOR structure for the supplied text."""
+
+    return orchestrator.process_user_input("session", req.text)

--- a/apps/router/__init__.py
+++ b/apps/router/__init__.py
@@ -1,1 +1,63 @@
-"""Routing service."""
+"""Routing service.
+
+The real project contains a highly sophisticated router that performs
+modality detection, semantic ranking and policy checks.  For the unit tests in
+this kata we only require a very small subset of this functionality.  The
+:class:`Router` class below acts as a façade around the placeholder modules in
+this package such as :mod:`gate` and :mod:`models`.
+
+Keeping the public method :meth:`route` compatible with the production code
+allows the HTTP layer and orchestrator to be exercised without pulling in any
+heavy dependencies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from lib.contracts.router_output import RouterOutput
+from lib.config.yaml_loader import load_yaml
+
+from . import gate
+
+
+@dataclass
+class Router:
+    """Minimal router facade used in tests.
+
+    Parameters
+    ----------
+    config: optional mapping loaded from ``router.yaml``.  The values are not
+        used directly but are stored to demonstrate how the real component would
+        be configured.
+    """
+
+    config: Any | None = field(default=None)
+    config_path: str = "config/router.yaml"
+
+    def __post_init__(self) -> None:
+        """Load configuration from ``config_path`` if no mapping was provided."""
+
+        if self.config is None and Path(self.config_path).exists():
+            self.config = load_yaml(self.config_path)
+
+    def route(self, text: str) -> RouterOutput:
+        """Return a :class:`RouterOutput` for the given ``text``.
+
+        The gate check is invoked for completeness but its return value is not
+        interpreted – the stub gate always allows the request.  A single
+        ``chat.general`` route is emitted which is sufficient for the higher
+        level components and unit tests.
+        """
+
+        gate.gate_request({"text": text})
+        # The configuration may define a default list of routes.  If not present
+        # we fall back to a single ``chat.general`` entry.
+        routes = self.config.get("default_routes", ["chat.general"]) if isinstance(self.config, dict) else ["chat.general"]
+        return RouterOutput(routes=routes)
+
+
+__all__ = ["Router"]
+

--- a/apps/router/main.py
+++ b/apps/router/main.py
@@ -1,8 +1,29 @@
-from fastapi import FastAPI
+"""HTTP wrapper around the lightweight router implementation.
 
+The endpoint defined here simply delegates to :class:`apps.router.Router`.  The
+class is intentionally tiny but its public interface mirrors the real system so
+the rest of the stack can be exercised end‑to‑end without relying on the
+monolithic reference implementation.
+"""
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from apps.router import Router
+
+
+router = Router()
 app = FastAPI()
 
+
+class RouteRequest(BaseModel):
+    """Incoming payload for the routing endpoint."""
+
+    text: str = ""
+
+
 @app.post("/route")
-async def route():
-    """Return a router output."""
-    return {"routes": []}
+async def route(req: RouteRequest):
+    """Return a router output for the provided text."""
+
+    return router.route(req.text)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,4 +8,9 @@ dependencies = [
     "pydantic",
     "faiss-cpu",
     "structlog",
+    "PyYAML",
+    "httpx",
 ]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]


### PR DESCRIPTION
## Summary
- introduce lightweight `Router`, `Orchestrator`, and `ChatAdapter` classes that load their own YAML configs
- wire FastAPI endpoints to the new modular services and drop the `monolithic.py` fallback
- declare `PyYAML` and `httpx` as runtime dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afd1a52214833290483cab15f21468