### PR TITLE
feat: yaml driven chat adapter

### DIFF
--- a/apps/chat_adapter/service.py
+++ b/apps/chat_adapter/service.py
@@ -1,5 +1,269 @@
-"""Request normalization logic for chat adapter."""
+"""Normalisation utilities for the chat adapter.
 
-def normalize_message(message: dict) -> dict:
-    """Placeholder normalization function."""
-    return message
+The real project performs a large number of pre‑processing steps before a
+message is handed over to the router.  For the purposes of the kata we
+implement a small but representative subset driven entirely by configuration
+values loaded from ``chat_adapter.yaml``.
+
+The module exposes the :func:`normalize_message` function which accepts a raw
+message mapping and returns a new mapping that follows the
+``MessageEnvelope@1`` structure defined in :mod:`lib.contracts.envelope`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Tuple
+import re
+import unicodedata
+
+from lib.config.chat_adapter_loader import AdapterConfig
+
+
+# ---------------------------------------------------------------------------
+# Chat session memory
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ChatMemory:
+    """Minimal session memory used for stickies.
+
+    Only a handful of fields are required for the exercises.  The memory keeps
+    track of the last seen file, URL and user text as well as an age counter
+    which allows stickies to expire after a configured number of turns.
+    """
+
+    last_file: str | None = None
+    last_url: str | None = None
+    last_text: str | None = None
+    turns_since_update: int = 0
+
+    def decay(self, ttl: int) -> None:
+        """Expire stickies if they have not been referenced for ``ttl`` turns."""
+
+        if ttl and self.turns_since_update >= ttl:
+            self.last_file = None
+            self.last_url = None
+            self.last_text = None
+            self.turns_since_update = 0
+        else:
+            self.turns_since_update += 1
+
+
+# ---------------------------------------------------------------------------
+# Basic sanitisation helpers
+# ---------------------------------------------------------------------------
+
+def _clean_text(raw: str, cfg: Dict[str, Any]) -> str:
+    """Apply the ``preprocess.clean`` rules from the configuration."""
+
+    s = raw or ""
+    if cfg.get("unicode_nfkc", True):
+        s = unicodedata.normalize("NFKC", s)
+    if cfg.get("strip_control_chars", True):
+        s = re.sub(r"[\u0000-\u001F\u007F]", "", s)
+    if cfg.get("normalize_quotes", True):
+        s = s.replace("“", '"').replace("”", '"').replace("‘", "'").replace("’", "'")
+    if cfg.get("normalize_dashes", True):
+        s = s.replace("—", "-").replace("–", "-")
+    # whitespace handling
+    if cfg.get("trim_whitespace", True):
+        s = s.strip()
+    if cfg.get("collapse_whitespace", True):
+        s = re.sub(r"\s+", " ", s)
+    # digit normalisation
+    digits_cfg = cfg.get("normalize_digits", {})
+    if digits_cfg.get("fa_to_ascii", True):
+        s = s.translate(str.maketrans("۰۱۲۳۴۵۶۷۸۹", "0123456789"))
+    if digits_cfg.get("ar_to_ascii", True):
+        s = s.translate(str.maketrans("٠١٢٣٤٥٦٧٨٩", "0123456789"))
+    max_len = int(cfg.get("max_text_len", 8000))
+    if len(s) > max_len:
+        if cfg.get("truncate_strategy") == "hard_tail":
+            s = s[-max_len:]
+        else:
+            s = s[:max_len]
+    return s
+
+
+def _detect_urls(text: str, cfg: Dict[str, Any], defaults: Dict[str, Any]) -> List[str]:
+    """Return URLs found in ``text`` according to configuration."""
+
+    if not cfg.get("enabled", True) or not text:
+        return []
+    pattern = cfg.get("regex_ref")
+    if pattern and pattern.startswith("defaults."):
+        key = pattern.split(".", 1)[1]
+        pattern = defaults.get(key, "")
+    regex = re.compile(pattern or r"https?://\S+")
+    allow = {s.lower() for s in cfg.get("allow_schemes", ["http", "https"])}
+    max_urls = int(cfg.get("max_urls", 5))
+    found = [u for u in regex.findall(text) if u.split(":", 1)[0].lower() in allow]
+    return found[:max_urls]
+
+
+def _label_attachments(attachments: List[Dict[str, Any]], cfg: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Assign ``media_type`` to attachments based on simple rules."""
+
+    if not attachments or not cfg.get("enabled", True):
+        return attachments or []
+    rules = cfg.get("rules", [])
+    labelled: List[Dict[str, Any]] = []
+    for att in attachments:
+        mime = (att.get("mime") or "").lower()
+        media_type = "unknown"
+        for rule in rules:
+            cond = rule.get("when", "")
+            if cond == "attachment.mime.startswith('image/')" and mime.startswith("image/"):
+                media_type = rule.get("as_media_type", "image")
+                break
+            if cond == "attachment.mime.startswith('audio/')" and mime.startswith("audio/"):
+                media_type = rule.get("as_media_type", "audio")
+                break
+            if cond == "attachment.mime.startswith('video/')" and mime.startswith("video/"):
+                media_type = rule.get("as_media_type", "video")
+                break
+            if cond == "attachment.mime == 'application/pdf'" and mime == "application/pdf":
+                media_type = rule.get("as_media_type", "document")
+                break
+            if cond == "attachment.mime.startswith('application/')" and mime.startswith("application/"):
+                media_type = rule.get("as_media_type", "document")
+                break
+        a = dict(att)
+        a.setdefault("media_type", media_type)
+        labelled.append(a)
+    return labelled
+
+
+def _attachments_guard(attachments: List[Dict[str, Any]], cfg: Dict[str, Any]) -> None:
+    """Perform early sanity checks on the attachments list."""
+
+    if not cfg:
+        return
+    if cfg.get("reject_if_missing_id", True):
+        for att in attachments:
+            if not att.get("file_id"):
+                raise ValueError("attachment missing file_id")
+    max_files = int(cfg.get("max_files", 5))
+    if len(attachments) > max_files:
+        raise ValueError("too many attachments")
+    total_bytes = 0
+    for att in attachments:
+        total_bytes += int(att.get("size", 0))
+    if total_bytes > int(cfg.get("max_total_bytes", 0)) > 0:
+        raise ValueError("attachments exceed size limit")
+
+
+def _infer_locale_tz(explicit_locale: str | None, explicit_tz: str | None, cfg: Dict[str, Any]) -> Tuple[str, str]:
+    """Infer locale and timezone with simple fallbacks."""
+
+    locale = explicit_locale or cfg.get("default_locale", "en-US")
+    tz_cfg = cfg.get("timezone", {})
+    tz = explicit_tz or tz_cfg.get("tz_by_locale", {}).get(locale)
+    if not tz:
+        tz = tz_cfg.get("default_tz", "UTC")
+    return locale, tz
+
+
+def _apply_stickies(text: str, urls: List[str], attachments: List[Dict[str, Any]], memory: ChatMemory, cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Update memory based on the current turn and return the snapshot."""
+
+    snapshot = {
+        "last_file": memory.last_file,
+        "last_url": memory.last_url,
+        "last_text": memory.last_text,
+        "last_intent_hint": None,
+    }
+
+    # clear on negation
+    clear_cfg = cfg.get("clear_on_negation", {})
+    if clear_cfg.get("enabled", True):
+        markers = [m.lower() for m in clear_cfg.get("negation_markers", {}).get("en", [])]
+        markers += [m.lower() for m in clear_cfg.get("negation_markers", {}).get("fa", [])]
+        low = text.lower()
+        if any(m in low for m in markers):
+            scope = clear_cfg.get("scope", [])
+            if "file" in scope:
+                snapshot["last_file"] = None
+                memory.last_file = None
+            if "url" in scope:
+                snapshot["last_url"] = None
+                memory.last_url = None
+            if "text" in scope:
+                snapshot["last_text"] = None
+                memory.last_text = None
+
+    # precedence – current turn artefacts win
+    prec = cfg.get("precedence", {})
+    if attachments and prec.get("prefer_current_attachments_over_stickies", True):
+        snapshot["last_file"] = None
+    if urls and prec.get("prefer_current_urls_over_stickies", True):
+        snapshot["last_url"] = None
+
+    # update memory with current artefacts
+    if attachments:
+        memory.last_file = attachments[-1].get("file_id")
+        memory.turns_since_update = 0
+    if urls:
+        memory.last_url = urls[-1]
+        memory.turns_since_update = 0
+    if text:
+        memory.last_text = text
+        memory.turns_since_update = 0
+
+    return snapshot
+
+
+def _build_adapter_hints(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the non‑binding adapter hints."""
+
+    hints = {
+        "target_lang": cfg.get("target_lang_default"),
+        "provider": cfg.get("provider_default", {}),
+        "safety_mode": cfg.get("safety_mode", "standard"),
+    }
+    propagate = cfg.get("propagate_to_router", [])
+    return {k: v for k, v in hints.items() if k in propagate and v is not None}
+
+
+# ---------------------------------------------------------------------------
+# Public normalisation entry point
+# ---------------------------------------------------------------------------
+
+def normalize_message(message: Dict[str, Any], cfg: AdapterConfig, memory: ChatMemory) -> Dict[str, Any]:
+    """Normalise ``message`` and return an envelope mapping.
+
+    Parameters
+    ----------
+    message:
+        Mapping with optional ``text``, ``attachments``, ``locale`` and
+        ``timezone`` keys.
+    cfg:
+        :class:`AdapterConfig` instance.
+    memory:
+        Session memory for the chat the message belongs to.  The memory is
+        updated in place.
+    """
+
+    raw_text = message.get("text", "")
+    sanitized = _clean_text(raw_text, cfg.clean)
+    urls = _detect_urls(sanitized, cfg.detect_urls, cfg.raw.get("defaults", {}))
+    attachments = _label_attachments(message.get("attachments", []), cfg.detect_media_types)
+    _attachments_guard(attachments, cfg.attachments_guard)
+    locale, tz = _infer_locale_tz(message.get("locale"), message.get("timezone"), cfg.locale)
+    snapshot = _apply_stickies(sanitized, urls, attachments, memory, cfg.sticky)
+    hints = _build_adapter_hints(cfg.hints)
+
+    envelope = {
+        "text": sanitized,
+        "urls": urls,
+        "attachments": attachments,
+        "locale": locale,
+        "timezone": tz,
+        "session_snapshot": snapshot,
+        "adapter_hints": hints,
+    }
+    return envelope
+
+
+__all__ = ["normalize_message", "ChatMemory"]

--- a/lib/config/chat_adapter_loader.py
+++ b/lib/config/chat_adapter_loader.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from .yaml_loader import load_yaml
+
+
+@dataclass
+class AdapterConfig:
+    """Typed view over ``chat_adapter.yaml``.
+
+    Only the keys required by the exercises are exposed.  The raw mapping is
+    retained so that lookups of shared defaults (such as regular expression
+    references) remain possible without having to duplicate the structure
+    in Python.
+    """
+
+    raw: Dict[str, Any]
+    clean: Dict[str, Any]
+    detect_urls: Dict[str, Any]
+    detect_media_types: Dict[str, Any]
+    attachments_guard: Dict[str, Any]
+    locale: Dict[str, Any]
+    sticky: Dict[str, Any]
+    hints: Dict[str, Any]
+
+
+def load_chat_adapter_config(path: str) -> AdapterConfig:
+    """Load ``chat_adapter.yaml`` and return an :class:`AdapterConfig`.
+
+    Parameters
+    ----------
+    path:
+        File system path to the YAML configuration file.
+    """
+
+    raw = load_yaml(path)
+    adapter = raw.get("adapter", {})
+    preprocess = adapter.get("preprocess", {})
+    return AdapterConfig(
+        raw=raw,
+        clean=preprocess.get("clean", {}),
+        detect_urls=preprocess.get("detect_urls", {}),
+        detect_media_types=preprocess.get("detect_media_types", {}),
+        attachments_guard=preprocess.get("attachments_guard", {}),
+        locale=adapter.get("locale", {}),
+        sticky=adapter.get("memory", {}).get("sticky_carry", {}),
+        hints=adapter.get("hints", {}),
+    )

--- a/lib/contracts/envelope.py
+++ b/lib/contracts/envelope.py
@@ -1,5 +1,26 @@
-"""MessageEnvelope model."""
-from pydantic import BaseModel
+"""MessageEnvelope model used by the chat adapter."""
+from typing import Any, Dict, List
+
+from pydantic import BaseModel, Field
+
+
+class Attachment(BaseModel):
+    """Representation of an attachment in the envelope."""
+
+    file_id: str | None = None
+    mime: str | None = None
+    media_type: str | None = None
+    size: int | None = None
+    sha256: str | None = None
+
 
 class MessageEnvelope(BaseModel):
-    message: str
+    """Normalised message passed from the adapter to the orchestrator."""
+
+    text: str = ""
+    urls: List[str] = Field(default_factory=list)
+    attachments: List[Attachment] = Field(default_factory=list)
+    locale: str = "en-US"
+    timezone: str = "UTC"
+    session_snapshot: Dict[str, Any] = Field(default_factory=dict)
+    adapter_hints: Dict[str, Any] = Field(default_factory=dict)


### PR DESCRIPTION
## Summary
- implement configurable ChatAdapter with per-chat memory and envelope assembly
- add YAML loader for adapter config
- expand MessageEnvelope to carry URLs, attachments, locale and hints

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afd96a62208332909abf4025bc9a54