### PR TITLE
Add chat adapter memory and config dataclasses

### DIFF
--- a/apps/chat_adapter/main.py
+++ b/apps/chat_adapter/main.py
@@ -15,7 +15,7 @@ from apps.router import Router
 
 router = Router()
 orchestrator = Orchestrator(router)
-adapter = ChatAdapter(orchestrator)
+adapter = ChatAdapter(orchestrator, router)
 app = FastAPI()
 
 

--- a/apps/chat_adapter/service.py
+++ b/apps/chat_adapter/service.py
@@ -12,8 +12,9 @@ message mapping and returns a new mapping that follows the
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Dict, List, Tuple
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Tuple, Optional
+import time
 import re
 import unicodedata
 
@@ -26,16 +27,31 @@ from lib.config.chat_adapter_loader import AdapterConfig
 
 @dataclass
 class ChatMemory:
-    """Minimal session memory used for stickies.
+    """In‑memory state for a chat session.
 
-    Only a handful of fields are required for the exercises.  The memory keeps
-    track of the last seen file, URL and user text as well as an age counter
-    which allows stickies to expire after a configured number of turns.
+    The adapter keeps track of the most recent attachments and user text as
+    well as a few intent related preferences.  The original stickies used by
+    ``normalize_message`` are retained for backwards compatibility.
     """
 
-    last_file: str | None = None
-    last_url: str | None = None
-    last_text: str | None = None
+    last_voice_file_id: Optional[str] = None
+    last_image_file_id: Optional[str] = None
+    last_doc_file_id: Optional[str] = None
+    last_user_text: Optional[str] = None
+    last_turn_ts: int = field(default_factory=lambda: int(time.time()))
+    pending_key: Optional[str] = None
+    pending_question: Optional[str] = None
+    user_lang_pref: Optional[str] = None  # 'fa' or 'en'
+    intended_pipeline: Optional[str] = None  # 'audio.stt', 'audio.transcribe_translate'
+    intended_target_lang: Optional[str] = None  # 'fa'/'en'
+    # Tutor preferences
+    tutor_target_lang: Optional[str] = None
+    tutor_native_lang: Optional[str] = None
+    tutor_daily_minutes: Optional[int] = None
+    # Legacy sticky fields
+    last_file: Optional[str] = None
+    last_url: Optional[str] = None
+    last_text: Optional[str] = None
     turns_since_update: int = 0
 
     def decay(self, ttl: int) -> None:

--- a/apps/router/__init__.py
+++ b/apps/router/__init__.py
@@ -36,6 +36,7 @@ class Router:
 
     config: Any | None = field(default=None)
     config_path: str = "config/router.yaml"
+    lang_hint: str = "fa"
     _impl: Any | None = field(default=None, init=False)
 
     def __post_init__(self) -> None:

--- a/apps/simple_dispatcher/__init__.py
+++ b/apps/simple_dispatcher/__init__.py
@@ -1,1 +1,35 @@
-"""Simple dispatcher service."""
+"""Simple dispatcher service.
+
+This module provides a very small stand‑in implementation used by the
+integration tests.  The real project dispatches tasks to a queue and later
+invokes agent services.  For the purposes of the exercises we merely record
+the enqueue request and return a confirmation dictionary.
+"""
+
+from typing import Any, Dict
+
+
+class SimpleDispatcher:
+    """Extremely small dispatcher used in tests.
+
+    The :meth:`enqueue` method mimics the behaviour of the production service
+    by accepting a handful of parameters and returning a result mapping.
+    """
+
+    def enqueue(
+        self,
+        agent: str,
+        aor: Dict[str, Any],
+        idempotency_key: str,
+        compiled_pipeline: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Pretend to enqueue a task and return a confirmation mapping."""
+
+        return {
+            "agent": agent,
+            "idempotency_key": idempotency_key,
+            "status": "queued",
+        }
+
+
+__all__ = ["SimpleDispatcher"]


### PR DESCRIPTION
## Summary
- expand `ChatMemory` to track recent attachments, user preferences and legacy stickies
- add runtime `AdapterConfig` options and import missing helpers
- provide minimal `SimpleDispatcher`, router `lang_hint`, and adjust main entrypoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afeefa07e88332b83909fa5fee6e3e