### PR TITLE
feat: load orchestrator config from yaml

### DIFF
--- a/apps/chat_adapter/main.py
+++ b/apps/chat_adapter/main.py
@@ -9,12 +9,12 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 
 from apps.chat_adapter import ChatAdapter
-from apps.orchestrator import Orchestrator
+from apps.orchestrator import AOROrchestrator
 from apps.router import Router
 
 
 router = Router()
-orchestrator = Orchestrator(router)
+orchestrator = AOROrchestrator(router)
 adapter = ChatAdapter(orchestrator, router)
 app = FastAPI()
 

--- a/apps/orchestrator/__init__.py
+++ b/apps/orchestrator/__init__.py
@@ -1,43 +1,169 @@
 """Orchestrator service.
 
-The orchestrator receives a plan skeleton from the router and wraps it in an
-``AOR`` (Action Oriented Response) object.  Only minimal functionality is
-implemented which keeps the module light weight while still demonstrating the
-flow through the architecture.
+This module provides :class:`AOROrchestrator` which compiles router output
+into an Action Oriented Response (AOR) structure.  The orchestrator reads its
+runtime configuration from ``config/orchestrator.yaml`` allowing the behaviour
+to be adjusted without code changes.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, List, Optional
+import uuid
 
-from lib.contracts.aor import AOR
 from lib.config.yaml_loader import load_yaml
+from lib.utils.helpers import _utcnow_iso
 
-from . import builder, idempotency
+# Re-export the idempotency helper module for backwards compatibility.
+from . import idempotency  # noqa: F401
+
+
+DEFAULT_SCHEMA_VERSION = "aor.v1"
 
 
 @dataclass
-class Orchestrator:
-    """Compile router output into an :class:`~lib.contracts.aor.AOR` instance."""
+class AOROrchestrator:
+    """Compile router output into a full AOR dictionary."""
 
     router: Any
-    config: Any | None = field(default=None)
+    config: Dict[str, Any] | None = field(default=None)
     config_path: str = "config/orchestrator.yaml"
+    schema_version: str = field(init=False, default=DEFAULT_SCHEMA_VERSION)
 
     def __post_init__(self) -> None:
         if self.config is None and Path(self.config_path).exists():
             self.config = load_yaml(self.config_path)
+        if isinstance(self.config, dict):
+            ver = (
+                self.config.get("orchestrator", {})
+                .get("aor", {})
+                .get("schema", {})
+                .get("version")
+            )
+            if ver:
+                self.schema_version = f"aor.v{ver}"
 
-    def process_user_input(self, session_id: str, text: str) -> AOR:
-        """Run the routing stage and build an ``AOR`` structure."""
+    @staticmethod
+    def _nodes_to_edges(nodes: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        edges: List[Dict[str, Any]] = []
+        for ns in nodes or []:
+            task_id = ns.get("task_id")
+            for dest, src in (ns.get("bind") or {}).items():
+                if isinstance(src, dict) and src.get("from_task"):
+                    edges.append(
+                        {
+                            "from": src["from_task"],
+                            "output": src.get("key", "text"),
+                            "to": task_id,
+                            "input": dest,
+                        }
+                    )
+        return edges
 
-        plan = self.router.route(text)
-        nodes = builder.build_nodes(plan.model_dump())
-        ensured = idempotency.ensure_idempotent(nodes)
-        return AOR(steps=ensured.get("routes", []))
+    def _build_aor(
+        self,
+        session_id: str,
+        text: str,
+        attachment: Optional[Dict[str, Any]],
+        plan: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        nodes = plan.get("nodes", []) or []
+        awaiting_input = plan.get("clarify") is not None
+        aor_nodes: List[Dict[str, Any]] = []
+        for ns in nodes:
+            aor_nodes.append(
+                {
+                    "task_id": ns.get("task_id"),
+                    "intent": ns.get("intent"),
+                    "input_declared": dict(ns.get("entities", {}) or {}),
+                    "bind": dict(ns.get("bind", {}) or {}),
+                    "ready": bool(ns.get("ready", False)),
+                    "missing": list(ns.get("missing", []) or []),
+                    "confidence": float(ns.get("confidence", 0.0)),
+                }
+            )
+        edges = self._nodes_to_edges(nodes)
+
+        aor: Dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "request": {
+                "request_id": plan.get("request_id"),
+                "session_id": session_id,
+                "submitted_at": _utcnow_iso(),
+                "input": {"text": text, "attachment": (attachment or None)},
+                "metadata": plan.get("metadata", {}),
+            },
+            "status": "waiting_input" if awaiting_input else "planned",
+            "final": False,
+            "plan": {
+                "plan_id": str(uuid.uuid4()),
+                "domain": plan.get("domain", "core"),
+                "nodes": aor_nodes,
+                "edges": edges,
+                "router_reply_text": plan.get("reply_text", ""),
+                "expected_outputs": plan.get("expected_outputs", {}),
+                "router_usage": plan.get("usage", {}),
+                "sr_debug": plan.get("sr_debug"),
+            },
+            "execution": {
+                "progress": 0.0,
+                "steps": [],
+                "outputs_keys": {},
+                "final_output": None,
+            },
+            "usage": plan.get("usage", {}),
+            "errors": [],
+        }
+
+        if awaiting_input:
+            q = plan.get("clarify", {}).get("question")
+            miss = plan.get("clarify", {}).get("missing", [])
+            aor["next_action"] = {
+                "type": "ask_user",
+                "awaiting_key": (miss[0] if miss else None),
+                "question": q,
+            }
+        else:
+            aor["next_action"] = {
+                "type": "enqueue",
+                "reason": "plan_ready_no_execution",
+            }
+
+        return aor
+
+    def process_user_input(
+        self,
+        user_id: str,
+        text: str,
+        attachment: Optional[Dict[str, Any]] = None,
+        extra_env: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        extra_env = dict(extra_env or {})
+        if attachment and attachment.get("file_id"):
+            extra_env["file_id"] = attachment["file_id"]
+            extra_env["media_type"] = attachment.get("media_type", "document")
+        try:
+            plan = self.router.route(
+                text or "",
+                session_id=user_id,
+                extra_env=extra_env,
+            )
+        except TypeError:  # Fallback to simple router used in tests
+            plan = self.router.route(text or "")
+        if hasattr(plan, "model_dump"):
+            plan = plan.model_dump()
+        if "adapter_hints" in extra_env:
+            plan.setdefault("metadata", {})["adapter_hints"] = extra_env.get(
+                "adapter_hints"
+            )
+        return self._build_aor(user_id, text, attachment, plan)
 
 
-__all__ = ["Orchestrator"]
+# Backwards compatible alias
+Orchestrator = AOROrchestrator
+
+
+__all__ = ["AOROrchestrator", "Orchestrator", "idempotency"]
 

--- a/apps/orchestrator/main.py
+++ b/apps/orchestrator/main.py
@@ -8,12 +8,12 @@ but mirror the public API of the production services.
 from fastapi import FastAPI
 from pydantic import BaseModel
 
-from apps.orchestrator import Orchestrator
+from apps.orchestrator import AOROrchestrator
 from apps.router import Router
 
 
 router = Router()
-orchestrator = Orchestrator(router)
+orchestrator = AOROrchestrator(router)
 app = FastAPI()
 
 


### PR DESCRIPTION
## Summary
- replace minimal orchestrator with new AOROrchestrator
- configure orchestrator from config/orchestrator.yaml
- update HTTP entry points to use the new orchestrator

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aff2f8d46083329157cf219f0e73f2